### PR TITLE
Time representation when exceeds 1 hour

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -36,7 +36,7 @@ pomodoro.on_pause_pomodoro_finish_callbacks = {}
 
 function pomodoro:settime(t)
   if t >= 3600 then -- more than one hour!
-    t = os.date("%X", t-3600)
+    t = os.date("!%X", t)
   else
     t = os.date("%M:%S", t)
   end


### PR DESCRIPTION
No one is assigned
 t = os.date("%X", t-3600)
This is only valid for UTC+1. I'm at UTC+7 and to get valid result, i need to substract 25200 from t. Example:

> print(os.date("%X", 0))
> 07:00:00
> As of lua wiki the format should be preceeded by an exclamation sign for the passed value to be treated as UTC:
> 
> print(os.date("!%X", 0))
> 00:00:00
> This should work for all time zones, no substraction required.
