### PR TITLE
[RFC] hide inactive timer

### DIFF
--- a/impl.lua
+++ b/impl.lua
@@ -32,7 +32,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
 
     pomodoro.format = function (t)
         if pomodoro.changed or pomodoro.timer.started then
-            return string.format("<b>%s</b>", t)
+            return string.format("Pomodoro: <b>%s</b>", t)
         else return ""
         end
     end

--- a/impl.lua
+++ b/impl.lua
@@ -108,6 +108,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
         pomodoro:settime(pomodoro.work_duration+pomodoro.change)
         pomodoro.work_duration = pomodoro.work_duration+pomodoro.change
         pomodoro.left = pomodoro.work_duration
+        pomodoro.changed_timer:again()
         pomodoro.changed_timer:start()
     end
 
@@ -119,6 +120,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
             pomodoro.work_duration = pomodoro.work_duration-pomodoro.change
             pomodoro.left = pomodoro.work_duration
         end
+        pomodoro.changed_timer:again()
         pomodoro.changed_timer:start()
     end
 

--- a/impl.lua
+++ b/impl.lua
@@ -18,10 +18,24 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
     pomodoro.work_duration = 25 * 60
     pomodoro.npomodoros = 0
     pomodoro.pause_duration = pomodoro.short_pause_duration
+
     pomodoro.change = 60
+    pomodoro.changed = false
+    pomodoro.changed_timer = timer({timeout = 3})
+    pomodoro.changed_timer:connect_signal("timeout", function ()
+        pomodoro.changed=false
+        pomodoro.changed_timer:again()
+        pomodoro.changed_timer:stop()
+        pomodoro.widget:set_text(pomodoro.format(pomodoro.work_duration))
+    end)
 
 
-    pomodoro.format = function (t) return "Pomodoro: <b>" .. t .. "</b>" end
+    pomodoro.format = function (t)
+        if pomodoro.changed or pomodoro.timer.started then
+            return string.format("<b>%s</b>", t)
+        else return ""
+        end
+    end
     pomodoro.pause_title = "Pause finished."
     pomodoro.pause_text = "Get back to work!"
     pomodoro.work_title = "Pomodoro finished."
@@ -89,19 +103,23 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
     end
 
     function pomodoro:increase_time()
+        pomodoro.changed = true
         pomodoro.timer:stop()
         pomodoro:settime(pomodoro.work_duration+pomodoro.change)
         pomodoro.work_duration = pomodoro.work_duration+pomodoro.change
         pomodoro.left = pomodoro.work_duration
+        pomodoro.changed_timer:start()
     end
 
     function pomodoro:decrease_time()
+        pomodoro.changed = true
         pomodoro.timer:stop()
         if pomodoro.work_duration > pomodoro.change then
             pomodoro:settime(pomodoro.work_duration-pomodoro.change)
             pomodoro.work_duration = pomodoro.work_duration-pomodoro.change
             pomodoro.left = pomodoro.work_duration
         end
+        pomodoro.changed_timer:start()
     end
 
     function get_buttons()

--- a/impl_test.lua
+++ b/impl_test.lua
@@ -65,6 +65,7 @@ end)
 
 describe('Set time should change the textbox appropriately', function()
     local s = spy.on(pomodoro.widget, "set_markup")
+    pomodoro.changed = true
     it('more than one hour pomodoro should be formatted with an hour part', function()
         pomodoro:settime(3601)
         assert.spy(s).was_called_with(pomodoro.widget, "Pomodoro: <b>01:00:01</b>")


### PR DESCRIPTION
This is a PR that hides the timer when the widget is not being used. That happens then in two scenarios:
1. The timer is not started
2. The timer is not being modified (eg. with the mouse wheel)

In the other scenarios the timer will be shown as expected.

Here's the PR results in action:

![GIF](http://i.imgur.com/IwDlAJD.gif)
