### PR TITLE
Updated to account for half an hour offsets in TZ

### DIFF
--- a/impl.lua
+++ b/impl.lua
@@ -50,7 +50,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
         if t >= 3600 then -- more than one hour!
             t = os.date("!%X", t)
         else
-            t = os.date("%M:%S", t)
+            t = os.date("!%M:%S", t)
         end
         self.widget:set_markup(pomodoro.format(t))
     end
@@ -238,9 +238,9 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
                 local collected = 'Collected ' .. pomodoro.npomodoros .. ' pomodoros so far.\n'
                 if pomodoro.timer.started then
                     if pomodoro.working then
-                        return collected .. 'Work ending in ' .. os.date("%M:%S", pomodoro.left)
+                        return collected .. 'Work ending in ' .. os.date("!%M:%S", pomodoro.left)
                     else
-                        return collected .. 'Rest ending in ' .. os.date("%M:%S", pomodoro.left)
+                        return collected .. 'Rest ending in ' .. os.date("!%M:%S", pomodoro.left)
                     end
                 else
                     return collected .. 'Pomodoro not started'


### PR DESCRIPTION
The updated version is time zone agnostic. Otherwise, the displayed time always has an offset if the current time zone has a half an hour offset from GMT. Consider not using os.date in this case too.

Ex : For UTC + 3.30, os.date("%M:%S",0) returns 30:00 and not 0:00 as expected.