### PR TITLE
Time display accounts for timezone

### DIFF
--- a/impl.lua
+++ b/impl.lua
@@ -13,18 +13,18 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
     -- pomodoro timer widget
     pomodoro = {}
     -- tweak these values in seconds to your liking
-    pomodoro.short_pause_duration = 5 * 60
-    pomodoro.long_pause_duration = 15 * 60
-    pomodoro.work_duration = 15 * 60
+    pomodoro.short_pause_duration = 5.5 * 60
+    pomodoro.long_pause_duration = 14 * 60
+    pomodoro.work_duration = 24 * 60
     pomodoro.npomodoros = 0
     pomodoro.pause_duration = pomodoro.short_pause_duration
     pomodoro.change = 60
 
 
-    pomodoro.format = function (t) return "Pomodoro: <b>" .. t .. "</b>" end
+    pomodoro.format = function (t) return "Current Slot: <b>" .. t .. "</b>" end
     pomodoro.pause_title = "Pause finished."
     pomodoro.pause_text = "Get back to work!"
-    pomodoro.work_title = "Pomodoro finished."
+    pomodoro.work_title = "Slot finished."
     pomodoro.work_text = "Time for a pause!"
     pomodoro.working = true
     pomodoro.widget = wibox.widget.textbox()
@@ -143,7 +143,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
             set_pomodoro_icon('gray')
             if pomodoro.working then
                 pomodoro.npomodoros = pomodoro.npomodoros + 1
-                if pomodoro.npomodoros % 4 == 0 then
+                if pomodoro.npomodoros % 3 == 0 then
                     pomodoro.pause_duration = pomodoro.long_pause_duration
                 else
                     pomodoro.pause_duration = pomodoro.short_pause_duration
@@ -235,7 +235,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
         awful.tooltip({
             objects = { pomodoro.widget, pomodoro.icon_widget},
             timer_function = function()
-                local collected = 'Collected ' .. pomodoro.npomodoros .. ' pomodoros so far.\n'
+                local collected = 'Worked for ' .. pomodoro.npomodoros .. ' slots so far.\n'
                 if pomodoro.timer.started then
                     if pomodoro.working then
                         return collected .. 'Work ending in ' .. os.date("!%M:%S", pomodoro.left)
@@ -243,7 +243,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
                         return collected .. 'Rest ending in ' .. os.date("!%M:%S", pomodoro.left)
                     end
                 else
-                    return collected .. 'Pomodoro not started'
+                    return collected .. 'Slot not started'
                 end
                 return 'Bad tooltip'
             end,

--- a/impl.lua
+++ b/impl.lua
@@ -15,7 +15,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
     -- tweak these values in seconds to your liking
     pomodoro.short_pause_duration = 5 * 60
     pomodoro.long_pause_duration = 15 * 60
-    pomodoro.work_duration = 25 * 60
+    pomodoro.work_duration = 15 * 60
     pomodoro.npomodoros = 0
     pomodoro.pause_duration = pomodoro.short_pause_duration
     pomodoro.change = 60
@@ -50,7 +50,7 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
         if t >= 3600 then -- more than one hour!
             t = os.date("!%X", t)
         else
-            t = os.date("%M:%S", t)
+            t = os.date("!%M:%S", t)
         end
         self.widget:set_markup(pomodoro.format(t))
     end
@@ -238,9 +238,9 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
                 local collected = 'Collected ' .. pomodoro.npomodoros .. ' pomodoros so far.\n'
                 if pomodoro.timer.started then
                     if pomodoro.working then
-                        return collected .. 'Work ending in ' .. os.date("%!M:%S", pomodoro.left)
+                        return collected .. 'Work ending in ' .. os.date("!%M:%S", pomodoro.left)
                     else
-                        return collected .. 'Rest ending in ' .. os.date("%!M:%S", pomodoro.left)
+                        return collected .. 'Rest ending in ' .. os.date("!%M:%S", pomodoro.left)
                     end
                 else
                     return collected .. 'Pomodoro not started'

--- a/impl.lua
+++ b/impl.lua
@@ -238,9 +238,9 @@ return function(wibox, awful, naughty, beautiful, timer, awesome)
                 local collected = 'Collected ' .. pomodoro.npomodoros .. ' pomodoros so far.\n'
                 if pomodoro.timer.started then
                     if pomodoro.working then
-                        return collected .. 'Work ending in ' .. os.date("%M:%S", pomodoro.left)
+                        return collected .. 'Work ending in ' .. os.date("%!M:%S", pomodoro.left)
                     else
-                        return collected .. 'Rest ending in ' .. os.date("%M:%S", pomodoro.left)
+                        return collected .. 'Rest ending in ' .. os.date("%!M:%S", pomodoro.left)
                     end
                 else
                     return collected .. 'Pomodoro not started'


### PR DESCRIPTION
The existing code does not take into account that some timezones have a non-integral multiple of hours offset in timezone. For instance, IST is UTC + 5.30 hours, when os.date is called to set the current time, this offset is not interpreted correctly. The changed line now accounts for this and works in case of any offset in timezone. 